### PR TITLE
[REFACTOR] 번들 사이즈 최적화

### DIFF
--- a/.github/ISSUE_TEMPLATE/refactor.md
+++ b/.github/ISSUE_TEMPLATE/refactor.md
@@ -1,0 +1,13 @@
+---
+name: REFACTOR
+about: Add refactoring
+title: "[REFACTOR]"
+labels: refactor
+assignees: silverain02
+---
+
+# 📌 문제 상황
+
+# 🗂️ 해결 방향
+
+# 🔗 참고 자료

--- a/app/letter/(with-home-header)/archive/page.tsx
+++ b/app/letter/(with-home-header)/archive/page.tsx
@@ -79,7 +79,7 @@ export const MyLetterPage = ({
 
   const handleCopyLink = () => {
     navigator.clipboard.writeText(
-      `${window.location.origin}/letter/${secretId?.secretLetterId}`,
+      `${window.location.origin}/letter/${secretId?.secretLetterId}`
     );
     toast.success("링크가 복사되었습니다");
   };
@@ -167,16 +167,16 @@ export default function ArchivePage() {
 
   // 편지 목록 보기 상태일 때
   return (
-    <article className="flex flex-col items-start justify-center px-5">
-      <header className="flex gap-2 items-center">
+    <article className="flex flex-col h-full px-5">
+      <header className="flex gap-2 items-center shrink-0">
         <Archive size={28} />
         <h1 className="typo-h2-3xl text-gray-900">올림 보관함</h1>
       </header>
-      <section className="w-full mt-5">
+      <section className="flex flex-col w-full mt-5 min-h-0 flex-1">
         <Tabs
           value={tabType}
           onValueChange={setTabType}
-          className="w-full h-10.5"
+          className="w-full h-10.5 shrink-0"
         >
           <TabsList className="w-full rounded-full h-10.5">
             {tabs.map((tab) => (
@@ -192,7 +192,7 @@ export default function ArchivePage() {
             ))}
           </TabsList>
         </Tabs>
-        <div className="px-2">
+        <div className="px-2 flex-1 min-h-0 overflow-y-auto mb-30">
           {tabType === "received" ? (
             <div className="w-full">
               {receivedLetter && receivedLetter.length > 0 ? (
@@ -229,7 +229,7 @@ export default function ArchivePage() {
             </div>
           )}
         </div>
-        <Button className="fixed bottom-15 left-0 right-0 w-[90%] mx-auto h-11.5 bg-[#E6002314] border-primary-700 border text-primary-700 typo-h1-base">
+        <Button className="fixed lg:w-95 bottom-15 left-0 right-0 w-[90%] mx-auto h-11.5 bg-[#E6002314] border-primary-700 border text-primary-700 typo-h1-base">
           <Link href="/letter/new/record">편지 작성하기</Link>
         </Button>
       </section>

--- a/app/letter/(with-home-header)/archive/page.tsx
+++ b/app/letter/(with-home-header)/archive/page.tsx
@@ -170,7 +170,7 @@ export default function ArchivePage() {
     <article className="flex flex-col h-full px-5">
       <header className="flex gap-2 items-center shrink-0">
         <Archive size={28} />
-        <h1 className="typo-h2-3xl text-gray-900">올림 보관함</h1>
+        <h1 className="typo-h2-3xl text-gray-900">편지함</h1>
       </header>
       <section className="flex flex-col w-full mt-5 min-h-0 flex-1">
         <Tabs

--- a/app/letter/(with-home-header)/complete/page.tsx
+++ b/app/letter/(with-home-header)/complete/page.tsx
@@ -59,7 +59,7 @@ export default function CompletePage() {
             "링크가 복사되었습니다. 편지를 전달해보세요",
             {
               className: "bg-gray-800 text-white shadow-lg",
-            },
+            }
           );
           setTimeout(() => toast.dismiss(id), 2000);
         })

--- a/app/letter/(with-home-header)/shop/page.tsx
+++ b/app/letter/(with-home-header)/shop/page.tsx
@@ -6,7 +6,7 @@ import Image from "next/image";
 export default function ShopPage() {
   return (
     <article className="flex flex-col h-full">
-      <header className="flex justify-end px-[20px]">
+      <header className="flex justify-end px-5">
         <p className="typo-body2-xs text-gray-600 py-2">홈 {">"} 굿즈제작</p>
       </header>
       <Image
@@ -17,7 +17,7 @@ export default function ShopPage() {
         className="w-full h-auto"
       />
 
-      <section className="flex flex-col gap-2 px-[20px] py-5">
+      <section className="flex flex-col gap-2 px-5 pt-3 overflow-auto">
         <h1 className="typo-h2-xl">NFC 카세트 테이프 키링 + 편지</h1>
         <h2 className="typo-h2-3xl">7,000원</h2>
         <div className="flex justify-between typo-body1-base py-4">
@@ -40,7 +40,7 @@ export default function ShopPage() {
           </div>
         </div>
       </section>
-      <div className="px-[20px] b-5">
+      <div className="px-5 b-5">
         <NavigationButton
           nextText="서비스 준비 중"
           isNextDisabled={true}

--- a/app/letter/new/record/page.tsx
+++ b/app/letter/new/record/page.tsx
@@ -2,10 +2,18 @@
 
 import dynamic from "next/dynamic";
 
-const RecordNote = dynamic(
-  () => import("@/components/record/RecordNote"),
-  { ssr: false }
-);
+const RecordNote = dynamic(() => import("@/components/record/RecordNote"), {
+  ssr: false,
+  loading: () => (
+    <div className="h-[30%]">
+      <div className="bg-gray-100 rounded-lg p-5">
+        <header className="flex justify-between items-center">
+          <h3 className="typo-h2-xl text-gray-900">Note</h3>
+        </header>
+      </div>
+    </div>
+  ),
+});
 import VoiceRecorderContainer from "@/components/record/VoiceRecorderContainer";
 import CompleteButtonContainer from "@/components/record/CompleteButtonContainer";
 import { useAtomValue } from "jotai";

--- a/app/letter/new/record/page.tsx
+++ b/app/letter/new/record/page.tsx
@@ -1,6 +1,11 @@
 "use client";
 
-import RecordNote from "@/components/record/RecordNote";
+import dynamic from "next/dynamic";
+
+const RecordNote = dynamic(
+  () => import("@/components/record/RecordNote"),
+  { ssr: false }
+);
 import VoiceRecorderContainer from "@/components/record/VoiceRecorderContainer";
 import CompleteButtonContainer from "@/components/record/CompleteButtonContainer";
 import { useAtomValue } from "jotai";

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -55,9 +55,9 @@ export default function Page() {
               href="/letter/archive"
               className="flex flex-col w-full items-start justify-center gap-2 bg-white border-gray-300 border rounded-lg px-5 py-5 shadow-md"
             >
-              <Archive size={24} className="text-primary-700" />
+              <Archive size={32} className="text-primary-700" />
               <div className="flex items-center justify-between gap-2 w-full">
-                <h3 className="typo-h2-lg text-gray-900 ">올림 보관함</h3>
+                <h3 className="typo-h2-lg text-gray-900 ">편지함</h3>
                 <p className="typo-body1-sm text-gray-500">
                   {letterCount?.count}개 보관중
                 </p>
@@ -80,8 +80,8 @@ export default function Page() {
             <Image
               src="/gif/mail-motion.gif"
               alt="mail-img"
-              width={30}
-              height={30}
+              width={32}
+              height={24}
             />
             <div
               className="flex flex-col items-start justify-between gap-2 w-full mt-0.5"

--- a/components/select/SelectPageContent.tsx
+++ b/components/select/SelectPageContent.tsx
@@ -6,7 +6,12 @@ import { useAudioPlayer } from "@/hooks/common/useAudioPlayer";
 import CompleteButtonContainer from "@/components/select/CompleteButtonContainer";
 import LetterBox from "@/components/select/LetterBox";
 import AudioPlayer from "@/components/select/AudioPlayer";
-import LetterOptionsBottomSheet from "@/components/select/LetterOptionsBottomSheet";
+import dynamic from "next/dynamic";
+
+const LetterOptionsBottomSheet = dynamic(
+  () => import("@/components/select/LetterOptionsBottomSheet"),
+  { ssr: false }
+);
 import FloatingButton from "@/components/select/FloatingButton";
 
 type TabType = "font" | "paper" | "bgm";

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -5,7 +5,7 @@ import { Slot } from "radix-ui"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
   {
     variants: {
       variant: {
@@ -22,11 +22,11 @@ const buttonVariants = cva(
       },
       size: {
         default: "h-9 px-4 py-2 has-[>svg]:px-3",
-        xs: "h-6 gap-1 rounded-md px-2 text-xs has-[>svg]:px-1.5 [&_svg:not([class*='size-'])]:size-3",
+        xs: "h-6 gap-1 rounded-md px-2 text-xs has-[>svg]:px-1.5",
         sm: "h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5",
         lg: "h-10 rounded-md px-6 has-[>svg]:px-4",
         icon: "size-9",
-        "icon-xs": "size-6 rounded-md [&_svg:not([class*='size-'])]:size-3",
+        "icon-xs": "size-6 rounded-md",
         "icon-sm": "size-8",
         "icon-lg": "size-10",
       },

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,9 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
+  experimental: {
+    optimizePackageImports: ["lucide-react", "framer-motion"],
+  },
   images: {
     remotePatterns: [
       {

--- a/providers/QueryProvider.tsx
+++ b/providers/QueryProvider.tsx
@@ -1,8 +1,17 @@
 "use client";
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
+import dynamic from "next/dynamic";
 import { useState } from "react";
+
+const ReactQueryDevtools =
+  process.env.NODE_ENV === "development"
+    ? dynamic(() =>
+        import("@tanstack/react-query-devtools").then(
+          (mod) => mod.ReactQueryDevtools
+        )
+      )
+    : () => null;
 
 export function QueryProvider({ children }: { children: React.ReactNode }) {
   const [queryClient] = useState(


### PR DESCRIPTION
## ✨ 변경 사항

- `optimizePackageImports`에 `lucide-react`, `framer-motion` 추가하여 배럴 임포트 트리셰이킹 개선
- `ReactQueryDevtools`를 `next/dynamic`으로 변경하여 프로덕션 번들에서 제외
- `LetterOptionsBottomSheet`를 동적 임포트로 전환 (사용자 클릭 시에만 로드)
- `RecordNote`를 동적 임포트로 전환 (아코디언 열기 전까지 지연 로드)

#48

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **문서**
  * 리팩터 관련 이슈 템플릿 추가(리포트 표준화)

* **최적화**
  * 특정 패키지 임포트 선택 최적화로 번들 경량화
  * 일부 UI 구성요소를 클라이언트 지연 로드로 초기 로딩 개선
  * 개발/프로덕션 환경에 따라 개발 도구 로드 제어로 런타임 효율 향상

* **스타일 / UI**
  * 여러 화면의 레이아웃·여백·텍스트(예: "편지함") 및 아이콘 크기 조정
  * 버튼 내 아이콘 기본 크기 규칙 제거
<!-- end of auto-generated comment: release notes by coderabbit.ai -->